### PR TITLE
Adding direct PDF creation of beamer slideshows to Markdown-build

### DIFF
--- a/Pandown Markdown.sublime-build
+++ b/Pandown Markdown.sublime-build
@@ -8,10 +8,6 @@
 		{ "name": "Run",
 		  "do_open": true
 		},
-		{ "name": "Pandown: PDF",
-		  "flag_pdf": true,
-		  "prevent_viewing": true
-		},
 		{ "name": "Pandown: Native Haskell",
 		  "pandoc_to": ["native", ".hs"]
 		},
@@ -36,8 +32,16 @@
 		{ "name": "Pandown: LaTeX",
 		  "pandoc_to": ["latex", ".tex"]
 		},
+		{ "name": "Pandown: LaTeX - PDF",
+		  "pandoc_to": ["latex", ".pdf"],
+		  "prevent_viewing": true
+		},
 		{ "name": "Pandown: LaTeX Beamer Slideshow",
 		  "pandoc_to": ["beamer", ".tex"]
+		},
+		{ "name": "Pandown: LaTeX Beamer Slideshow - PDF",
+		  "pandoc_to": ["beamer", ".pdf"],
+		  "prevent_viewing": true
 		},
 		{ "name": "Pandown: ConTeXt",
 		  "pandoc_to": ["context", ".tex"]


### PR DESCRIPTION
The PDF build in the current build-settings forces you to use only one output type, standard latex by default, but I needed to sometimes build beamer slide pdfs too so I've added that build type. Since you can just specify "latex" or "beamer" as target formats with a .pdf extension this means that the explicit treatment using the pdf_flag is actually not necessary, so I've changed the format of the old 'PDF' build command too.

If you're fine with these changes I can also add them to the two other build-settings (and potentially chuck out the self.makePDF stuff in the BuildCommand)

Many thanks for the package, it's awesome!
