### PR TITLE
Compatibility with Pandoc 2

### DIFF
--- a/Pandown.sublime-settings
+++ b/Pandown.sublime-settings
@@ -211,7 +211,14 @@
 
 			// Straight quotes into curly quotes, --- to em-dash, -- to en-dash,
 			// ... to ellipsis, nonbreaking spaces after certain abbreviations.
-			"smart": true
+			"smart": true,
+			
+			// "Parse untranslatable HTML codes as raw HTML, instead of ignoring them."
+			"raw_html": true,
+
+			// "Parse untranslatable LaTeX environments as raw LaTeX, instead of 
+			// ignoring them."
+			"raw_tex": true
 		},
 
 
@@ -239,10 +246,6 @@
 			// setting; otherwise, to set an include directory, use the "includes_paths"
 			// option above.
 			"data-dir": "",
-
-			// "Parse untranslatable HTML codes and LaTeX environments as
-			// raw HTML or LaTeX, instead of ignoring them."
-			"parse-raw": true,
 
 			// - before a numeral to en-dash, -- to em-dash
 			"old-dashes": false,

--- a/Pandown.sublime-settings
+++ b/Pandown.sublime-settings
@@ -407,8 +407,7 @@
 			// "Use the specified file as a style reference in producing a [desired] file.
 			// For best results, the reference [file] should be a modified version of
 			// a [desired] file produced using pandoc."
-			"reference-odt": "",
-			"reference-docx": "",
+			"reference-doc": "",
 
 			// "Use the specified CSS file to style the EPUB. If no stylesheet is specified,
 			// pandoc will look for a file epub.css in the user data directory (see --data-dir).

--- a/Pandown.sublime-settings
+++ b/Pandown.sublime-settings
@@ -271,9 +271,6 @@
 			// will be used.
 			"default-image-extension": "",
 			
-			// Merge adjacent elements, remove repeated spaces, etc.
-			"normalize": true,
-
 			// Set the number of spaces per tab. Should be set to
 			// "false" (for default behavior) or a number.
 			"tab-stop": false,

--- a/Pandown.sublime-settings
+++ b/Pandown.sublime-settings
@@ -207,7 +207,11 @@
 
 			// Parses MMD-style header identifiers (in square brackets between header
 			// text and closing ATX #s.
-			"mmd_header_identifiers": false
+			"mmd_header_identifiers": false,
+
+			// Straight quotes into curly quotes, --- to em-dash, -- to en-dash,
+			// ... to ellipsis, nonbreaking spaces after certain abbreviations.
+			"smart": true
 		},
 
 
@@ -239,10 +243,6 @@
 			// "Parse untranslatable HTML codes and LaTeX environments as
 			// raw HTML or LaTeX, instead of ignoring them."
 			"parse-raw": true,
-
-			// Straight quotes into curly quotes, --- to em-dash, -- to en-dash,
-			// ... to ellipsis, nonbreaking spaces after certain abbreviations.
-			"smart": true,
 
 			// - before a numeral to en-dash, -- to em-dash
 			"old-dashes": false,

--- a/default-pandoc-config-plain.json
+++ b/default-pandoc-config-plain.json
@@ -45,12 +45,13 @@
 			"autolink_bare_uris": false,
 			"link_attributes": false,
 			"mmd_header_identifiers": false,
-			"smart": true
+			"smart": true,
+			"raw_html": true,
+			"raw_tex": true
 		},
 		"command_arguments":
 		{
 			"data-dir": "",
-			"parse-raw": true,
 			"old-dashes": false,
 			"base-header-level": false,
 			"indented-code-classes":

--- a/default-pandoc-config-plain.json
+++ b/default-pandoc-config-plain.json
@@ -94,8 +94,7 @@
 			"css":
 			[
 			],
-			"reference-odt": "",
-			"reference-docx": "",
+			"reference-doc": "",
 			"epub-stylesheet": "",
 			"epub-coverimage": "",
 			"epub-metadata": "",

--- a/default-pandoc-config-plain.json
+++ b/default-pandoc-config-plain.json
@@ -58,7 +58,6 @@
 			[
 			],
 			"default-image-extension": "",
-			"normalize": true,
 			"tab-stop": false,
 			"standalone": true,
 			"template": "",

--- a/default-pandoc-config-plain.json
+++ b/default-pandoc-config-plain.json
@@ -44,13 +44,13 @@
 			"abbreviations": false,
 			"autolink_bare_uris": false,
 			"link_attributes": false,
-			"mmd_header_identifiers": false
+			"mmd_header_identifiers": false,
+			"smart": true
 		},
 		"command_arguments":
 		{
 			"data-dir": "",
 			"parse-raw": true,
-			"smart": true,
 			"old-dashes": false,
 			"base-header-level": false,
 			"indented-code-classes":

--- a/default-pandoc-config.json
+++ b/default-pandoc-config.json
@@ -365,8 +365,7 @@
 			// "Use the specified file as a style reference in producing a [desired] file.
 			// For best results, the reference [file] should be a modified version of
 			// a [desired] file produced using pandoc."
-			"reference-odt": "",
-			"reference-docx": "",
+			"reference-doc": "",
 
 			// "Use the specified CSS file to style the EPUB. If no stylesheet is specified,
 			// pandoc will look for a file epub.css in the user data directory (see --data-dir).

--- a/default-pandoc-config.json
+++ b/default-pandoc-config.json
@@ -172,7 +172,14 @@
 
 			// Straight quotes into curly quotes, --- to em-dash, -- to en-dash,
 			// ... to ellipsis, nonbreaking spaces after certain abbreviations.
-			"smart": true
+			"smart": true,
+			
+			// "Parse untranslatable HTML codes as raw HTML, instead of ignoring them."
+			"raw_html": true,
+
+			// "Parse untranslatable LaTeX environments as raw LaTeX, instead of 
+			// ignoring them."
+			"raw_tex": true
 		},
 
 		"command_arguments":
@@ -197,10 +204,6 @@
 			// setting; otherwise, to set an include directory, use the "includes_paths"
 			// option above.
 			"data-dir": "",
-
-			// "Parse untranslatable HTML codes and LaTeX environments as
-			// raw HTML or LaTeX, instead of ignoring them."
-			"parse-raw": true,
 
 			// - before a numeral to en-dash, -- to em-dash
 			"old-dashes": false,

--- a/default-pandoc-config.json
+++ b/default-pandoc-config.json
@@ -168,11 +168,12 @@
 
 			// Parses MMD-style header identifiers (in square brackets between header
 			// text and closing ATX #s.
-			"mmd_header_identifiers": false
+			"mmd_header_identifiers": false,
+
+			// Straight quotes into curly quotes, --- to em-dash, -- to en-dash,
+			// ... to ellipsis, nonbreaking spaces after certain abbreviations.
+			"smart": true
 		},
-
-
-
 
 		"command_arguments":
 		{
@@ -200,10 +201,6 @@
 			// "Parse untranslatable HTML codes and LaTeX environments as
 			// raw HTML or LaTeX, instead of ignoring them."
 			"parse-raw": true,
-
-			// Straight quotes into curly quotes, --- to em-dash, -- to en-dash,
-			// ... to ellipsis, nonbreaking spaces after certain abbreviations.
-			"smart": true,
 
 			// - before a numeral to en-dash, -- to em-dash
 			"old-dashes": false,

--- a/default-pandoc-config.json
+++ b/default-pandoc-config.json
@@ -229,9 +229,6 @@
 			// will be used.
 			"default-image-extension": "",
 			
-			// Merge adjacent elements, remove repeated spaces, etc.
-			"normalize": true,
-
 			// Set the number of spaces per tab. Should be set to
 			// "false" (for default behavior) or a number.
 			"tab-stop": false,


### PR DESCRIPTION
Pandoc 2 changed `smart` and `parse-raw`from command arguments to filters, and removed `normalize`.  The `reference-odt` and `reference-docx` options were also merged into `reference-doc`.

This PR makes those changes within Pandown; the items formerly in "command_arguments" are moved to the bottom of the "markdown_extensions" section.